### PR TITLE
Handle consecutive spaces in queries

### DIFF
--- a/app/Query.scala
+++ b/app/Query.scala
@@ -17,11 +17,11 @@ case class ParsedQuery(terms: List[String], filters: Map[String, String]) {
 
 object QueryParser {
   
-  private val spaceRegex = " +".r
+  private val spaceRegex = "[ +]+".r
 
   def apply(q: String, filterKeys: Seq[String]): ParsedQuery = {
 
-    val terms = spaceRegex.split(q.trim.toLowerCase.replace("+", " ")).toList
+    val terms = spaceRegex.split(q.trim.toLowerCase).toList
 
     terms.foldLeft(ParsedQuery(Nil, Map.empty)) {
       case (parsed, term) =>

--- a/app/Query.scala
+++ b/app/Query.scala
@@ -16,10 +16,12 @@ case class ParsedQuery(terms: List[String], filters: Map[String, String]) {
 }
 
 object QueryParser {
+  
+  private val spaceRegex = " +".r
 
   def apply(q: String, filterKeys: Seq[String]): ParsedQuery = {
 
-    val terms = q.trim.toLowerCase.replace("+", " ").split(" ").toList
+    val terms = spaceRegex.split(q.trim.toLowerCase.replace("+", " ")).toList
 
     terms.foldLeft(ParsedQuery(Nil, Map.empty)) {
       case (parsed, term) =>

--- a/app/Query.scala
+++ b/app/Query.scala
@@ -16,7 +16,7 @@ case class ParsedQuery(terms: List[String], filters: Map[String, String]) {
 }
 
 object QueryParser {
-  
+
   private val spaceRegex = "[ +]+".r
 
   def apply(q: String, filterKeys: Seq[String]): ParsedQuery = {


### PR DESCRIPTION
Fixes https://github.com/ornicar/lila/issues/9458

I think I figured it out! The study search uses `minimumShouldMatch 1` on [line 70](https://github.com/ornicar/lila-search/blob/a3fb3ebeae2aaa1304dd7643bb959ea2330da018/app/study.scala#L70) which matches studies if at least one token from the query finds a match. Extra nonsense tokens pose no problem. The forum search and team search don't have anything like this, so they require every token from the query to match something. This causes problems for forum and team search if empty string tokens sneak into queries.

At first, I thought Elasticsearch would be in charge of tokenizing queries, but it looks like we do that [here](https://github.com/ornicar/lila-search/blob/a3fb3ebeae2aaa1304dd7643bb959ea2330da018/app/Query.scala#L22). And splitting on spaces leads to empty tokens. Since we tokenize ourselves, I feel a lot better about fixing the problem with a regex.